### PR TITLE
BE-feat-소환사 프로필 API

### DIFF
--- a/node/app.js
+++ b/node/app.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const dotenv = require('dotenv');
 // const axios = require('axios');
-// const https = require('https');
+const https = require('https');
 // const urlencode = require('urlencode');
 const app = express();
 
@@ -39,6 +39,12 @@ app.get('/test', async function (req, res) {
   //   "summonerLevel": 257
   //   }
 });
+
+// app.get('/champion', function (req, res) {
+//   const champObj;
+
+//   res.send(champObj);
+// });
 
 app.listen(port, function () {
   process.send('ready');

--- a/node/app.js
+++ b/node/app.js
@@ -6,6 +6,7 @@ const dotenv = require('dotenv');
 const app = express();
 
 const summoner = require('./routes/summoner');
+const riotAPI = require('./riotAPI');
 
 dotenv.config();
 const port = process.env.PORT;
@@ -22,6 +23,21 @@ app.use('/api/summoner', summoner);
 app.get('/', async function (req, res) {
   res.write('<h1>NG.GG RIOT API</h1>');
   res.send();
+});
+
+app.get('/test', async function (req, res) {
+  const { id } = await riotAPI.getSummonerInfoByName('소송왕잡스');
+  const summonerLeagueObject = await riotAPI.getSummoerLeagueInfo(id);
+  res.send(summonerLeagueObject);
+  // {
+  //   "id": "6zChb2CMq4LbR6VKNzmznSrwimXRV0JRNdTNdH9mQgGo8A",
+  //   "accountId": "yP-JNUmVxanbXuXwmzoNYeGqIMAu5iFUalt7rc71uUpL",
+  //   "puuid": "BZ62xI7WZLoEN2-dfD1yIIHXitFCdshPZiTH-4AEU4Kr6KcvqTBDeuDCys_-dQBQ3bgAyKvH1jzWeA",
+  //   "name": "소송왕잡스",
+  //   "profileIconId": 4863,
+  //   "revisionDate": 1612941381000,
+  //   "summonerLevel": 257
+  //   }
 });
 
 app.listen(port, function () {

--- a/node/riotAPI/index.js
+++ b/node/riotAPI/index.js
@@ -10,6 +10,7 @@ module.exports = {
       https.get(urls.summoner_v4(encodedName), function (response) {
         response.on('data', function (data) {
           const summonerData = JSON.parse(data);
+
           resolve(summonerData);
         });
       });
@@ -27,6 +28,16 @@ module.exports = {
           });
         }
       );
+    });
+  },
+  getSummoerLeagueInfo: function (summonerId) {
+    return new Promise(function (resolve, reject) {
+      https.get(urls.league_v4(summonerId), function (response) {
+        response.on('data', function (data) {
+          const leagueInfo = JSON.parse(data);
+          resolve(leagueInfo);
+        });
+      });
     });
   },
 };

--- a/node/riotAPI/utils/url.js
+++ b/node/riotAPI/utils/url.js
@@ -11,4 +11,18 @@ module.exports = {
       `?endIndex=${endIndex}&beginIndex=${beginIndex}&api_key=${process.env.RIOT_API_KEY}`
     );
   },
+
+  league_v4: function (encryptedSummonerId) {
+    return (
+      `https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/` +
+      `${encryptedSummonerId}?api_key=${process.env.RIOT_API_KEY}`
+    );
+  },
+
+  profileIconUrl: function (profileIconId) {
+    return (
+      `http://ddragon.leagueoflegends.com/cdn/11.3.1/img/profileicon/` +
+      `${profileIconId}.png`
+    );
+  },
 };

--- a/node/routes/summoner.js
+++ b/node/routes/summoner.js
@@ -13,7 +13,7 @@ router.get('/matchhistory/:summonerName', async function (req, res) {
   const summonerName = req.params.summonerName;
   const summonerInfo = await riotAPI.getSummonerInfoByName(summonerName);
 
-  if (summonerInfo.status === undefined) {
+  if (!summonerInfo.status) {
     const { accountId } = summonerInfo;
     const beginIndex = 0;
     const endIndex = 20;

--- a/node/routes/summoner.js
+++ b/node/routes/summoner.js
@@ -1,6 +1,7 @@
 var router = require('express').Router();
 
 const riotAPI = require('../riotAPI');
+const urls = require('../riotAPI/utils/url');
 
 router.get('/:summonerName', async function (req, res) {
   const summonerName = req.params.summonerName;
@@ -10,15 +11,62 @@ router.get('/:summonerName', async function (req, res) {
 
 router.get('/matchhistory/:summonerName', async function (req, res) {
   const summonerName = req.params.summonerName;
-  const { accountId } = await riotAPI.getSummonerInfoByName(summonerName);
-  const beginIndex = 0;
-  const endIndex = 20;
-  const matchHistory = await riotAPI.getSummonerMantchHistory(
-    accountId,
-    beginIndex,
-    endIndex
-  );
-  res.send(matchHistory);
+  const summonerInfo = await riotAPI.getSummonerInfoByName(summonerName);
+
+  if (summonerInfo.status === undefined) {
+    const { accountId } = summonerInfo;
+    const beginIndex = 0;
+    const endIndex = 20;
+    const matchHistory = await riotAPI.getSummonerMantchHistory(
+      accountId,
+      beginIndex,
+      endIndex
+    );
+    res.send(matchHistory);
+  } else {
+    res.send(summonerInfo);
+  }
+});
+
+router.get('/profile/:summonerName', async function (req, res) {
+  const summonerName = req.params.summonerName;
+  const summonerInfo = await riotAPI.getSummonerInfoByName(summonerName);
+
+  if (summonerInfo.status === undefined) {
+    const { id, profileIconId } = summonerInfo;
+
+    const summonerLeagueObject = await riotAPI.getSummoerLeagueInfo(id);
+    const profileIconUrl = urls.profileIconUrl(profileIconId);
+
+    const [teamLankAllObject, soloLankAllObject] = summonerLeagueObject;
+
+    const teamLankObject = {
+      tier: teamLankAllObject.tier,
+      rank: teamLankAllObject.rank,
+      leaguePoints: teamLankAllObject.leaguePoints,
+      wins: teamLankAllObject.wins,
+      losses: teamLankAllObject.losses,
+    };
+
+    const soloLankObject = {
+      tier: soloLankAllObject.tier,
+      rank: soloLankAllObject.rank,
+      leaguePoints: soloLankAllObject.leaguePoints,
+      wins: soloLankAllObject.wins,
+      losses: soloLankAllObject.losses,
+    };
+
+    const leagueInfo = {
+      summmonerName: summonerName,
+      profileIconUrl: profileIconUrl,
+      soloLank: soloLankObject,
+      teamLank: teamLankObject,
+    };
+
+    res.send(leagueInfo);
+  } else {
+    res.send(summonerInfo);
+  }
 });
 
 module.exports = router;

--- a/node/routes/summoner.js
+++ b/node/routes/summoner.js
@@ -22,9 +22,21 @@ router.get('/matchhistory/:summonerName', async function (req, res) {
       beginIndex,
       endIndex
     );
-    res.send(matchHistory);
+
+    const responseObject = {
+      message: 'API success',
+      data: matchHistory,
+    };
+
+    res.send(responseObject);
   } else {
-    res.send(summonerInfo);
+    const responseObject = {
+      message: 'API fail - unregistered summoner name.',
+      data: {
+        requestedName: summonerName,
+      },
+    };
+    res.send(responseObject);
   }
 });
 
@@ -79,9 +91,21 @@ router.get('/profile/:summonerName', async function (req, res) {
       teamRank: teamRankObject,
     };
 
-    res.send(leagueInfo);
+    const responseObject = {
+      message: 'API success',
+      data: leagueInfo,
+    };
+
+    res.send(responseObject);
   } else {
-    res.send(summonerInfo);
+    const responseObject = {
+      message: 'API fail - unregistered summoner name.',
+      data: {
+        requestedName: summonerName,
+      },
+    };
+
+    res.status(404).send(responseObject);
   }
 });
 

--- a/node/routes/summoner.js
+++ b/node/routes/summoner.js
@@ -32,35 +32,51 @@ router.get('/profile/:summonerName', async function (req, res) {
   const summonerName = req.params.summonerName;
   const summonerInfo = await riotAPI.getSummonerInfoByName(summonerName);
 
-  if (summonerInfo.status === undefined) {
+  if (!summonerInfo.status) {
     const { id, profileIconId } = summonerInfo;
-
-    const summonerLeagueObject = await riotAPI.getSummoerLeagueInfo(id);
     const profileIconUrl = urls.profileIconUrl(profileIconId);
 
-    const [teamLankAllObject, soloLankAllObject] = summonerLeagueObject;
+    const summonerLeagueObject = await riotAPI.getSummoerLeagueInfo(id);
 
-    const teamLankObject = {
-      tier: teamLankAllObject.tier,
-      rank: teamLankAllObject.rank,
-      leaguePoints: teamLankAllObject.leaguePoints,
-      wins: teamLankAllObject.wins,
-      losses: teamLankAllObject.losses,
+    const teamRankObject = {
+      tier: 'unranked',
+      rank: null,
+      leaguePoints: null,
+      wins: null,
+      losses: null,
     };
 
-    const soloLankObject = {
-      tier: soloLankAllObject.tier,
-      rank: soloLankAllObject.rank,
-      leaguePoints: soloLankAllObject.leaguePoints,
-      wins: soloLankAllObject.wins,
-      losses: soloLankAllObject.losses,
+    const soloRankObject = {
+      tier: 'unranked',
+      rank: null,
+      leaguePoints: null,
+      wins: null,
+      losses: null,
     };
+
+    if (summonerLeagueObject.length > 0) {
+      summonerLeagueObject.forEach((leagueObject) => {
+        if (leagueObject.queueType === 'RANKED_FLEX_SR') {
+          teamRankObject.tier = leagueObject.tier;
+          teamRankObject.rank = leagueObject.rank;
+          teamRankObject.leaguePoints = leagueObject.leaguePoints;
+          teamRankObject.wins = leagueObject.wins;
+          teamRankObject.losses = leagueObject.losses;
+        } else if (leagueObject.queueType === 'RANKED_SOLO_5x5') {
+          soloRankObject.tier = leagueObject.tier;
+          soloRankObject.rank = leagueObject.rank;
+          soloRankObject.leaguePoints = leagueObject.leaguePoints;
+          soloRankObject.wins = leagueObject.wins;
+          soloRankObject.losses = leagueObject.losses;
+        }
+      });
+    }
 
     const leagueInfo = {
       summmonerName: summonerName,
       profileIconUrl: profileIconUrl,
-      soloLank: soloLankObject,
-      teamLank: teamLankObject,
+      soloLank: soloRankObject,
+      teamRank: teamRankObject,
     };
 
     res.send(leagueInfo);


### PR DESCRIPTION
### 📗 작업 내역

- 소환사 이름으로 소환사 프로필 정보 조회 API 구현. 
- undefined 소환사 이름으로 API 호출 시 bad request 동작 처리 구현 

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 버그 수정

<br/>

### 📝 PR 특이 사항
- getSummoerLeagueInfo()  : 소환사 랭크 정보를 반환하는 함수
- get('/api/summoner/profile/:summonerName') : 소환사 프로필 표현에 필요한 정보를 반환하는 API 

<br/><br/>
