### PR TITLE
BE-소환사 대전 기록 요청 API

### DIFF
--- a/node/app.js
+++ b/node/app.js
@@ -3,7 +3,12 @@ const dotenv = require('dotenv');
 // const axios = require('axios');
 const https = require('https');
 // const urlencode = require('urlencode');
+<<<<<<< HEAD
 const cors = require('cors');
+=======
+const urls = require('./riotAPI/utils/url');
+
+>>>>>>> feat: 소환사이름에 해당하는 대전 기록 요청 API
 const app = express();
 
 const summoner = require('./routes/summoner');
@@ -29,18 +34,11 @@ app.get('/', async function (req, res) {
 });
 
 app.get('/test', async function (req, res) {
-  const { id } = await riotAPI.getSummonerInfoByName('소송왕잡스');
-  const summonerLeagueObject = await riotAPI.getSummoerLeagueInfo(id);
-  res.send(summonerLeagueObject);
-  // {
-  //   "id": "6zChb2CMq4LbR6VKNzmznSrwimXRV0JRNdTNdH9mQgGo8A",
-  //   "accountId": "yP-JNUmVxanbXuXwmzoNYeGqIMAu5iFUalt7rc71uUpL",
-  //   "puuid": "BZ62xI7WZLoEN2-dfD1yIIHXitFCdshPZiTH-4AEU4Kr6KcvqTBDeuDCys_-dQBQ3bgAyKvH1jzWeA",
-  //   "name": "소송왕잡스",
-  //   "profileIconId": 4863,
-  //   "revisionDate": 1612941381000,
-  //   "summonerLevel": 257
-  //   }
+  let testQuery = req.query.startIndex;
+  if (!testQuery) {
+    testQuery = 950902;
+  }
+  res.send('testval : ' + testQuery);
 });
 
 // app.get('/champion', function (req, res) {

--- a/node/app.js
+++ b/node/app.js
@@ -3,12 +3,7 @@ const dotenv = require('dotenv');
 // const axios = require('axios');
 const https = require('https');
 // const urlencode = require('urlencode');
-<<<<<<< HEAD
 const cors = require('cors');
-=======
-const urls = require('./riotAPI/utils/url');
-
->>>>>>> feat: 소환사이름에 해당하는 대전 기록 요청 API
 const app = express();
 
 const summoner = require('./routes/summoner');
@@ -34,11 +29,18 @@ app.get('/', async function (req, res) {
 });
 
 app.get('/test', async function (req, res) {
-  let testQuery = req.query.startIndex;
-  if (!testQuery) {
-    testQuery = 950902;
-  }
-  res.send('testval : ' + testQuery);
+  const { id } = await riotAPI.getSummonerInfoByName('소송왕잡스');
+  const summonerLeagueObject = await riotAPI.getSummoerLeagueInfo(id);
+  res.send(summonerLeagueObject);
+  // {
+  //   "id": "6zChb2CMq4LbR6VKNzmznSrwimXRV0JRNdTNdH9mQgGo8A",
+  //   "accountId": "yP-JNUmVxanbXuXwmzoNYeGqIMAu5iFUalt7rc71uUpL",
+  //   "puuid": "BZ62xI7WZLoEN2-dfD1yIIHXitFCdshPZiTH-4AEU4Kr6KcvqTBDeuDCys_-dQBQ3bgAyKvH1jzWeA",
+  //   "name": "소송왕잡스",
+  //   "profileIconId": 4863,
+  //   "revisionDate": 1612941381000,
+  //   "summonerLevel": 257
+  //   }
 });
 
 // app.get('/champion', function (req, res) {

--- a/node/riotAPI/index.js
+++ b/node/riotAPI/index.js
@@ -40,4 +40,15 @@ module.exports = {
       });
     });
   },
+
+  getOneMatchDetail(matchId) {
+    return new Promise(function (resolve, reject) {
+      https.get(urls.match_v4_matchDetails(matchId), function (response) {
+        response.on('data', function (data) {
+          const matchDetail = JSON.parse(data);
+          resolve(matchDetail);
+        });
+      });
+    });
+  },
 };

--- a/node/riotAPI/index.js
+++ b/node/riotAPI/index.js
@@ -1,5 +1,6 @@
 const https = require('https');
 const urlencode = require('urlencode');
+const { get } = require('../routes/summoner');
 const urls = require('./utils/url');
 
 module.exports = {
@@ -43,10 +44,49 @@ module.exports = {
 
   getOneMatchDetail(matchId) {
     return new Promise(function (resolve, reject) {
+      let mergeData = '';
       https.get(urls.match_v4_matchDetails(matchId), function (response) {
         response.on('data', function (data) {
-          const matchDetail = JSON.parse(data);
-          resolve(matchDetail);
+          mergeData += data;
+        });
+
+        response.on('end', function () {
+          const returnData = JSON.parse(mergeData);
+          resolve(returnData);
+        });
+      });
+    });
+  },
+
+  getChampionList() {
+    return new Promise(function (resolve, reject) {
+      let mergeData = '';
+
+      https.get(urls.championListUrl(), function (response) {
+        response.on('data', function (data) {
+          mergeData += data;
+        });
+
+        response.on('end', function () {
+          const returnData = JSON.parse(mergeData);
+          resolve(returnData);
+        });
+      });
+    });
+  },
+
+  getSpellList() {
+    return new Promise(function (resolve, reject) {
+      let mergeData = '';
+
+      https.get(urls.spellListUrl(), function (response) {
+        response.on('data', function (data) {
+          mergeData += data;
+        });
+
+        response.on('end', function () {
+          const returnData = JSON.parse(mergeData);
+          resolve(returnData);
         });
       });
     });

--- a/node/riotAPI/utils/url.js
+++ b/node/riotAPI/utils/url.js
@@ -12,6 +12,10 @@ module.exports = {
     );
   },
 
+  match_v4_matchDetails: function (matchId) {
+    return `https://kr.api.riotgames.com/lol/match/v4/matches/${matchId}?api_key=${process.env.RIOT_API_KEY}`;
+  },
+
   league_v4: function (encryptedSummonerId) {
     return (
       `https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/` +

--- a/node/riotAPI/utils/url.js
+++ b/node/riotAPI/utils/url.js
@@ -25,8 +25,28 @@ module.exports = {
 
   profileIconUrl: function (profileIconId) {
     return (
-      `http://ddragon.leagueoflegends.com/cdn/11.3.1/img/profileicon/` +
+      `https://ddragon.leagueoflegends.com/cdn/11.3.1/img/profileicon/` +
       `${profileIconId}.png`
     );
+  },
+
+  championListUrl: function () {
+    return `https://ddragon.leagueoflegends.com/cdn/11.3.1/data/en_US/champion.json`;
+  },
+
+  championImageUrlByName: function (champName) {
+    return `https://ddragon.leagueoflegends.com/cdn/11.3.1/img/champion/${champName}.png`;
+  },
+
+  spellListUrl: function () {
+    return `https://ddragon.leagueoflegends.com/cdn/11.3.1/data/en_US/summoner.json`;
+  },
+
+  spellImageUrlByName: function (spellName) {
+    return `https://ddragon.leagueoflegends.com/cdn/11.3.1/img/spell/${spellName}.png`;
+  },
+
+  itemImageUrlById: function (itemId) {
+    return `https://ddragon.leagueoflegends.com/cdn/11.3.1/img/item/${itemId}.png`;
   },
 };

--- a/node/routes/summoner.js
+++ b/node/routes/summoner.js
@@ -40,6 +40,41 @@ router.get('/matchhistory/:summonerName', async function (req, res) {
   }
 });
 
+router.get(
+  '/matchhistory/matchdetails/:summonerName',
+  async function (req, res) {
+    const summonerName = req.params.summonerName;
+    const summonerInfo = await riotAPI.getSummonerInfoByName(summonerName);
+
+    if (!summonerInfo.status) {
+      const { accountId } = summonerInfo;
+      const beginIndex = 0;
+      const endIndex = 20;
+      const matchHistory = await riotAPI.getSummonerMantchHistory(
+        accountId,
+        beginIndex,
+        endIndex
+      );
+
+      const matchIdArray = [];
+      const matches = matchHistory.matches;
+      matches.forEach((match) => {
+        matchIdArray.push(match.gameId);
+      });
+
+      res.send(matchIdArray);
+    } else {
+      const responseObject = {
+        message: 'API fail - unregistered summoner name.',
+        data: {
+          requestedName: summonerName,
+        },
+      };
+      res.send(responseObject);
+    }
+  }
+);
+
 router.get('/profile/:summonerName', async function (req, res) {
   const summonerName = req.params.summonerName;
   const summonerInfo = await riotAPI.getSummonerInfoByName(summonerName);


### PR DESCRIPTION
### 📗 작업 내역

- `GET` /api/summoner/matchhistory/matchdetail/{summonerName} API
- 소환사 이름에 해당하는 대전 기록 요청 API
- Query Parameter 없이 요청시 가장 최근 한 개의 대전 기록 반환 (beginIndex=0, endIndex=1)
- Query Parameter : beginIndex, endIndex 

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 버그 수정
- 리펙토링


<br/>

### 📝 PR 특이 사항

- API example 1 : /api/summoner/matchhistory/matchdetail/{summonerName}
- API example 2 : /api/summoner/matchhistory/matchdetail/{summonerName}?endIndex=5
- API example 3 : /api/summoner/matchhistory/matchdetail/{summonerName}?beginIndex=6&endIndex=10


<br/><br/>
